### PR TITLE
fix the name of the image on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ cd docker-misp
 ./build.sh
 ```
 
-This will produce an image called: ```harvarditsecurity/docker-misp```
+This will produce an image called: ```harvarditsecurity/misp```
 
 # How to run it in 3 steps:
 


### PR DESCRIPTION
The image created is called `harvarditsecurity/misp` instead of `harvarditsecurity/docker-misp`, as defined in the `build.sh` file, so it's just a simple update to the docs.